### PR TITLE
Feat/navigation UI implementaion

### DIFF
--- a/nextjs/src/app/globals.css
+++ b/nextjs/src/app/globals.css
@@ -1,8 +1,8 @@
 @import 'tailwindcss';
 
 @theme {
-  --color-background: var(--background);
-  --color-foreground: var(--foreground);
+    --color-background: var(--background);
+    --color-foreground: var(--foreground);
 }
 
 /*
@@ -14,29 +14,35 @@
   color utility to any element that depends on these defaults.
 */
 @layer base {
-  *,
-  ::after,
-  ::before,
-  ::backdrop,
-  ::file-selector-button {
-    border-color: var(--color-gray-200, currentcolor);
-  }
+
+    *,
+    ::after,
+    ::before,
+    ::backdrop,
+    ::file-selector-button {
+        border-color: var(--color-gray-200, currentcolor);
+    }
+
+    html,
+    body {
+        @apply overscroll-x-contain;
+    }
 }
 
 :root {
-  --background: #ffffff;
-  --foreground: #171717;
+    --background: #ffffff;
+    --foreground: #171717;
 }
 
 @media (prefers-color-scheme: dark) {
-  :root {
-    --background: #0a0a0a;
-    --foreground: #ededed;
-  }
+    :root {
+        --background: #0a0a0a;
+        --foreground: #ededed;
+    }
 }
 
 body {
-  color: var(--foreground);
-  background: var(--background);
-  font-family: Arial, Helvetica, sans-serif;
+    color: var(--foreground);
+    background: var(--background);
+    font-family: Arial, Helvetica, sans-serif;
 }

--- a/nextjs/src/app/page.tsx
+++ b/nextjs/src/app/page.tsx
@@ -5,7 +5,10 @@ import NavSection from '../components/NavSection';
 import MainSection from '../components/MainSection';
 
 export default function Home() {
-    const mainSectionRef = useRef<{ handleShuffle: () => void } | null>(null);
+    const mainSectionRef = useRef<{
+        handleShuffle: () => void,
+        handleBind: () => void
+    } | null>(null);
 
     const handleShuffle = () => {
         if (mainSectionRef.current) {
@@ -13,9 +16,18 @@ export default function Home() {
         }
     };
 
+    const handleBind = () => {
+        if (mainSectionRef.current) {
+            mainSectionRef.current.handleBind();
+        }
+    };
+
     return (
         <div className="m-0 p-0 overflow-hidden bg-[#ccb7e0] min-h-screen">
-            <NavSection onShuffle={handleShuffle} />
+            <NavSection
+                onShuffle={handleShuffle}
+                onBind={handleBind}
+            />
             <MainSection ref={mainSectionRef} />
         </div>
     );

--- a/nextjs/src/app/page.tsx
+++ b/nextjs/src/app/page.tsx
@@ -7,7 +7,8 @@ import MainSection from '../components/MainSection';
 export default function Home() {
     const mainSectionRef = useRef<{
         handleShuffle: () => void,
-        handleBind: () => void
+        handleBind: () => void,
+        handleVertical: () => void
     } | null>(null);
 
     const handleShuffle = () => {
@@ -22,11 +23,18 @@ export default function Home() {
         }
     };
 
+    const handleVertical = () => {
+        if (mainSectionRef.current) {
+            mainSectionRef.current.handleVertical();
+        }
+    };
+
     return (
         <div className="m-0 p-0 overflow-hidden bg-[#ccb7e0] min-h-screen">
             <NavSection
                 onShuffle={handleShuffle}
                 onBind={handleBind}
+                onVertical={handleVertical}
             />
             <MainSection ref={mainSectionRef} />
         </div>

--- a/nextjs/src/components/Card.tsx
+++ b/nextjs/src/components/Card.tsx
@@ -14,7 +14,9 @@ type CardProps = {
     width: string;
     transform: string;
     isShuffling: boolean;
+    isBinding: boolean;
     zIndex: number;
+    dataCardIndex: number;
     handleMouseDown: (e: React.MouseEvent | React.TouchEvent | React.PointerEvent) => void;
     handleMouseMove: (e: React.MouseEvent | React.TouchEvent | React.PointerEvent) => void;
     handleMouseUp: (e: React.MouseEvent | React.TouchEvent | React.PointerEvent) => void;
@@ -35,7 +37,9 @@ export default function Card({
     width,
     transform,
     isShuffling,
-    zIndex
+    isBinding,
+    zIndex,
+    dataCardIndex
 }: CardProps) {
     const imgRef = useRef<HTMLImageElement>(null);
 
@@ -44,6 +48,7 @@ export default function Card({
             ref={imgRef}
             src={src || getCardBackFileName()}
             alt={name + commentary + faceUpFileName}
+            data-card-index={dataCardIndex}
             onMouseDown={handleMouseDown}
             onTouchStart={handleMouseDown}
             onMouseMove={handleMouseMove}
@@ -59,7 +64,7 @@ export default function Card({
                 height: 'auto',
                 transform: transform,
                 cursor: 'pointer',
-                transition: isShuffling ? 'all 1s ease-in-out' : 'none',
+                transition: isShuffling || isBinding ? 'all 1s ease-in-out' : 'none',
                 zIndex: zIndex
             }}
         />

--- a/nextjs/src/components/Card.tsx
+++ b/nextjs/src/components/Card.tsx
@@ -15,6 +15,7 @@ type CardProps = {
     transform: string;
     isShuffling: boolean;
     isBinding: boolean;
+    isVertical: boolean;
     zIndex: number;
     dataCardIndex: number;
     handleMouseDown: (e: React.MouseEvent | React.TouchEvent | React.PointerEvent) => void;
@@ -38,6 +39,7 @@ export default function Card({
     transform,
     isShuffling,
     isBinding,
+    isVertical,
     zIndex,
     dataCardIndex
 }: CardProps) {
@@ -64,7 +66,7 @@ export default function Card({
                 height: 'auto',
                 transform: transform,
                 cursor: 'pointer',
-                transition: isShuffling || isBinding ? 'all 1s ease-in-out' : 'none',
+                transition: isShuffling || isBinding || isVertical ? 'all 1s ease-in-out' : 'none',
                 zIndex: zIndex
             }}
         />

--- a/nextjs/src/components/CardList.tsx
+++ b/nextjs/src/components/CardList.tsx
@@ -51,8 +51,8 @@ const CardList = forwardRef<CardListHandle>((_, ref) => {
         const dataList = tmpList.map(value => ({
             ...value,
             src: getCardBackFileName(),
-            top: `${getRandom(0, innerWidth / 2)}px`,
-            left: `${getRandom(0, innerHeight / 2)}px`,
+            top: `${getRandom(0, Math.round(innerWidth / 2))}px`,
+            left: `${getRandom(0, Math.round(innerHeight / 2))}px`,
             width: `100px`,
             transform: `0deg`,
             zIndex: getRandom(1, 100)
@@ -82,8 +82,8 @@ const CardList = forwardRef<CardListHandle>((_, ref) => {
         const newCardList = cardList.map((card, index) => ({
             ...card,
             src: getCardBackFileName(),
-            top: `${getRandom(0, innerWidth / 2)}px`,
-            left: `${getRandom(0, innerHeight / 2)}px`,
+            top: `${getRandom(0, Math.round(innerWidth / 2))}px`,
+            left: `${getRandom(0, Math.round(innerHeight / 2))}px`,
             transform: `rotate(${getRandom(0, 360)}deg)`,
             zIndex: zIndexArray[index] // ランダムなz-indexを割り当て
         }));

--- a/nextjs/src/components/CardList.tsx
+++ b/nextjs/src/components/CardList.tsx
@@ -21,12 +21,14 @@ type CardData = {
 export type CardListHandle = {
     shuffleCards: () => void;
     bindCards: () => void;
+    verticalCards: () => void;
 };
 
 const CardList = forwardRef<CardListHandle>((_, ref) => {
     const [cardList, setCardList] = useState<CardData[]>([]);
     const [isShuffling, setIsShuffling] = useState<boolean>(false);
     const [isBinding, setIsBinding] = useState<boolean>(false);
+    const [isVertical, setIsVertical] = useState<boolean>(false);
     const [isMouseDown, setIsMouseDown] = useState<boolean>(false);
     const [zIndexCount, setZIndexCount] = useState<number>(200);
     const [startMouseDownX, setStartMouseDownX] = useState<number>(0);
@@ -36,7 +38,8 @@ const CardList = forwardRef<CardListHandle>((_, ref) => {
 
     useImperativeHandle(ref, () => ({
         shuffleCards,
-        bindCards
+        bindCards,
+        verticalCards
     }));
 
     useEffect(() => {
@@ -59,7 +62,7 @@ const CardList = forwardRef<CardListHandle>((_, ref) => {
     }, []);
 
     const shuffleCards = () => {
-        console.log('シャッフル処理を実行');
+        //console.log('シャッフル処理を実行');
         if (isShuffling) return;
         setIsShuffling(true);
 
@@ -93,7 +96,7 @@ const CardList = forwardRef<CardListHandle>((_, ref) => {
     };
 
     const bindCards = () => {
-        console.log('束ねる処理を実行');
+        //console.log('束ねる処理を実行');
         if (isBinding) return;
         setIsBinding(true);
 
@@ -120,6 +123,24 @@ const CardList = forwardRef<CardListHandle>((_, ref) => {
         // アニメーション完了後に状態をリセット
         setTimeout(() => {
             setIsBinding(false);
+        }, 1000);
+    };
+
+    const verticalCards = () => {
+        console.log('縦にする処理を実行');
+        if (isVertical) return;
+        setIsVertical(true);
+
+        // 縦にする処理
+        const newCardList = cardList.map((card) => ({
+            ...card,
+            transform: `rotate(${getRandom(0, 1) ? 180 : 0}deg)`,
+        }));
+        setCardList(newCardList);
+
+        // アニメーション完了後に状態をリセット
+        setTimeout(() => {
+            setIsVertical(false);
         }, 1000);
     };
 
@@ -152,7 +173,11 @@ const CardList = forwardRef<CardListHandle>((_, ref) => {
             const cardIndex = parseInt(target.dataset.cardIndex || '0');
             return prevList.map((card, index) =>
                 index === cardIndex
-                    ? { ...card, left: `${newLeft}px`, top: `${newTop}px` }
+                    ? {
+                        ...card,
+                        left: `${newLeft}px`,
+                        top: `${newTop}px`
+                    }
                     : card
             );
         });
@@ -172,16 +197,32 @@ const CardList = forwardRef<CardListHandle>((_, ref) => {
             const cardIndex = parseInt(target.dataset.cardIndex || '0');
             return prevList.map((card, index) =>
                 index === cardIndex
-                    ? { ...card, left: `${newLeft}px`, top: `${newTop}px` }
+                    ? {
+                        ...card,
+                        left: `${newLeft}px`,
+                        top: `${newTop}px`
+                    }
                     : card
             );
         });
     }
 
-    function handleDoubleClick(e: React.MouseEvent | React.TouchEvent | React.PointerEvent, index: number) {
+    function handleDoubleClick(e: React.MouseEvent | React.TouchEvent | React.PointerEvent) {
         e.stopPropagation();
         const target = e.currentTarget as HTMLImageElement;
-        target.src = target.src.includes(getCardBackFileName()) ? cardList[index].face_up_file_name : getCardBackFileName();
+        //target.src = target.src.includes(getCardBackFileName()) ? cardList[index].face_up_file_name : getCardBackFileName();
+        // React状態を更新
+        setCardList(prevList => {
+            const cardIndex = parseInt(target.dataset.cardIndex || '0');
+            return prevList.map((card, index) =>
+                index === cardIndex
+                    ? {
+                        ...card,
+                        src: card.src.includes(getCardBackFileName()) ? card.face_up_file_name : getCardBackFileName()
+                    }
+                    : card
+            );
+        });
     }
 
     return (
@@ -196,13 +237,14 @@ const CardList = forwardRef<CardListHandle>((_, ref) => {
                     handleMouseDown={handleMouseDown}
                     handleMouseMove={handleMouseMove}
                     handleMouseUp={handleMouseUp}
-                    handleDoubleClick={(e) => handleDoubleClick(e, index)}
+                    handleDoubleClick={handleDoubleClick}
                     top={value.top}
                     left={value.left}
                     width={value.width}
                     transform={value.transform}
                     isShuffling={isShuffling}
                     isBinding={isBinding}
+                    isVertical={isVertical}
                     zIndex={value.zIndex}
                     dataCardIndex={index}
                 />

--- a/nextjs/src/components/MainSection.tsx
+++ b/nextjs/src/components/MainSection.tsx
@@ -5,17 +5,26 @@ import CardList from '../components/CardList';
 
 export type MainSectionHandle = {
     handleShuffle: () => void;
+    handleBind: () => void;
 };
 
 const MainSection = forwardRef<MainSectionHandle>((_, ref) => {
     const mainRef = useRef<HTMLElement | null>(null);
     const [showCard, setShowCard] = useState(false);
-    const cardListRef = useRef<{ shuffleCards: () => void } | null>(null);
+    const cardListRef = useRef<{
+        shuffleCards: () => void,
+        bindCards: () => void,
+    } | null>(null);
 
     useImperativeHandle(ref, () => ({
         handleShuffle: () => {
             if (cardListRef.current) {
                 cardListRef.current.shuffleCards();
+            }
+        },
+        handleBind: () => {
+            if (cardListRef.current) {
+                cardListRef.current.bindCards();
             }
         }
     }));

--- a/nextjs/src/components/MainSection.tsx
+++ b/nextjs/src/components/MainSection.tsx
@@ -6,6 +6,7 @@ import CardList from '../components/CardList';
 export type MainSectionHandle = {
     handleShuffle: () => void;
     handleBind: () => void;
+    handleVertical: () => void;
 };
 
 const MainSection = forwardRef<MainSectionHandle>((_, ref) => {
@@ -14,6 +15,7 @@ const MainSection = forwardRef<MainSectionHandle>((_, ref) => {
     const cardListRef = useRef<{
         shuffleCards: () => void,
         bindCards: () => void,
+        verticalCards: () => void
     } | null>(null);
 
     useImperativeHandle(ref, () => ({
@@ -26,16 +28,21 @@ const MainSection = forwardRef<MainSectionHandle>((_, ref) => {
             if (cardListRef.current) {
                 cardListRef.current.bindCards();
             }
+        },
+        handleVertical: () => {
+            if (cardListRef.current) {
+                cardListRef.current.verticalCards();
+            }
         }
     }));
 
-    useEffect(() => {
+    /*useEffect(() => {
         if (mainRef.current) {
             console.log('mainタグのDOM要素:', mainRef.current);
             console.log('高さ:', mainRef.current.offsetHeight);
             console.log('幅:', mainRef.current.offsetWidth);
         }
-    }, []);
+    }, []);*/
 
     useEffect(() => {
         const timer = setTimeout(() => setShowCard(true), 500);

--- a/nextjs/src/components/NavSection.tsx
+++ b/nextjs/src/components/NavSection.tsx
@@ -20,7 +20,7 @@ export default function NavSection({ onShuffle, onBind, onVertical }: NavSection
     };
 
     return (
-        <div className="absolute top-4 right-4 z-50">
+        <div className="absolute top-4 right-4 z-999">
             {/* ハンバーガーメニューボタン */}
             <button
                 onClick={toggleMenu}

--- a/nextjs/src/components/NavSection.tsx
+++ b/nextjs/src/components/NavSection.tsx
@@ -1,5 +1,7 @@
 'use client';
 
+import { useState } from 'react';
+
 type NavSectionProps = {
     onShuffle: () => void;
     onBind: () => void;
@@ -7,30 +9,62 @@ type NavSectionProps = {
 }
 
 export default function NavSection({ onShuffle, onBind, onVertical }: NavSectionProps) {
+    const [isOpen, setIsOpen] = useState(false);
+
+    const toggleMenu = () => {
+        setIsOpen(!isOpen);
+    };
+
+    const handleMenuClick = (action: () => void) => {
+        action();
+    };
+
     return (
-        <div className="absolute top-0 right-0">
-            <nav>
-                <ul className="flex flex-col gap-4 p-4">
-                    <li
-                        className="cursor-pointer hover:text-blue-500 transition-colors"
-                        onClick={onShuffle}
-                    >
-                        混ぜる
-                    </li>
-                    <li
-                        className="cursor-pointer hover:text-blue-500 transition-colors"
-                        onClick={onBind}
-                    >
-                        束ねる
-                    </li>
-                    <li
-                        className="cursor-pointer hover:text-blue-500 transition-colors"
-                        onClick={onVertical}
-                    >
-                        縦にする
-                    </li>
-                </ul>
-            </nav>
+        <div className="absolute top-4 right-4 z-50">
+            {/* ハンバーガーメニューボタン */}
+            <button
+                onClick={toggleMenu}
+                className="cursor-pointer flex flex-col justify-center items-center w-12 h-12 bg-white rounded-lg shadow-lg hover:bg-gray-100 transition-colors"
+                aria-label="メニューを開く"
+            >
+                <span className={`block w-6 h-0.5 bg-gray-600 transition-all duration-300 ${isOpen ? 'rotate-45 absolute top-0 bottom-0 m-auto' : ''}`}></span>
+                <span className={`block w-6 h-0.5 bg-gray-600 mt-1.5 transition-all duration-300 ${isOpen ? 'opacity-0' : ''}`}></span>
+                <span className={`block w-6 h-0.5 bg-gray-600 transition-all duration-300 ${isOpen ? 'rotate-135 absolute top-0 bottom-0 m-auto' : 'mt-1.5'}`}></span>
+            </button>
+
+            {/* ドロップダウンメニュー */}
+            {isOpen && (
+                <div className="absolute top-14 right-0 bg-white rounded-lg shadow-lg border border-gray-200 min-w-32">
+                    <nav>
+                        <ul className="py-2">
+                            <li>
+                                <button
+                                    onClick={() => handleMenuClick(onShuffle)}
+                                    className="cursor-pointer w-full text-left px-4 py-2 text-black transition-colors"
+                                >
+                                    混ぜる
+                                </button>
+                            </li>
+                            <li>
+                                <button
+                                    onClick={() => handleMenuClick(onBind)}
+                                    className="cursor-pointer w-full text-left px-4 py-2 text-black transition-colors"
+                                >
+                                    束ねる
+                                </button>
+                            </li>
+                            <li>
+                                <button
+                                    onClick={() => handleMenuClick(onVertical)}
+                                    className="cursor-pointer w-full text-left px-4 py-2 text-black transition-colors"
+                                >
+                                    縦にする
+                                </button>
+                            </li>
+                        </ul>
+                    </nav>
+                </div>
+            )}
         </div>
     );
 }

--- a/nextjs/src/components/NavSection.tsx
+++ b/nextjs/src/components/NavSection.tsx
@@ -2,9 +2,10 @@
 
 type NavSectionProps = {
     onShuffle: () => void;
+    onBind: () => void;
 }
 
-export default function NavSection({ onShuffle }: NavSectionProps) {
+export default function NavSection({ onShuffle, onBind }: NavSectionProps) {
     return (
         <div className="absolute top-0 right-0">
             <nav>
@@ -15,7 +16,12 @@ export default function NavSection({ onShuffle }: NavSectionProps) {
                     >
                         混ぜる
                     </li>
-                    <li className="cursor-pointer hover:text-blue-500 transition-colors">束ねる</li>
+                    <li
+                        className="cursor-pointer hover:text-blue-500 transition-colors"
+                        onClick={onBind}
+                    >
+                        束ねる
+                    </li>
                     <li className="cursor-pointer hover:text-blue-500 transition-colors">縦にする</li>
                 </ul>
             </nav>

--- a/nextjs/src/components/NavSection.tsx
+++ b/nextjs/src/components/NavSection.tsx
@@ -3,9 +3,10 @@
 type NavSectionProps = {
     onShuffle: () => void;
     onBind: () => void;
+    onVertical: () => void;
 }
 
-export default function NavSection({ onShuffle, onBind }: NavSectionProps) {
+export default function NavSection({ onShuffle, onBind, onVertical }: NavSectionProps) {
     return (
         <div className="absolute top-0 right-0">
             <nav>
@@ -22,7 +23,12 @@ export default function NavSection({ onShuffle, onBind }: NavSectionProps) {
                     >
                         束ねる
                     </li>
-                    <li className="cursor-pointer hover:text-blue-500 transition-colors">縦にする</li>
+                    <li
+                        className="cursor-pointer hover:text-blue-500 transition-colors"
+                        onClick={onVertical}
+                    >
+                        縦にする
+                    </li>
                 </ul>
             </nav>
         </div>


### PR DESCRIPTION
## 変更の概要
混ぜる、束ねる、縦にするのカードアクションの実装とハンバーガーメニューの構築をしました。

## 変更の目的や背景
カードを手動で混ぜていたのが手間なのと、束ねる機能が無かったので実装しました。
これにより、臨場感の演出がでるのでリアルに近い感じを提供できるようになりました。

## 関連Issue
[](https://github.com/YoshihisaSaitou/quantum-card-app-3/issues/6)

## スクリーンショット
![screencapture-localhost-2025-07-06-16_42_19](https://github.com/user-attachments/assets/4979f69c-78f7-4025-a556-f31b371a2ab0)

## 動作確認
<!-- 動作確認の内容を記載してください -->
- [x] レイアウトが崩れていない
- [x] 混ぜるのボタン押下で混ぜるアクションが実行する
- [x] 束ねるボタン押下で束ねるアクションが実行する
- [x] 縦にするボタン押下で縦にするアクションが実行する