### PR TITLE
Feat/initial card placement smartphone screens

### DIFF
--- a/nextjs/src/components/CardList.tsx
+++ b/nextjs/src/components/CardList.tsx
@@ -46,11 +46,6 @@ const CardList = forwardRef<CardListHandle>((_, ref) => {
         const innerWidth = window.innerWidth;
         const innerHeight = window.innerHeight;
 
-        console.log('innerWidth:', innerWidth);
-        console.log('Math.round(innerWidth / 2):', Math.round(innerWidth / 2));
-        console.log('innerHeight:', innerHeight);
-        console.log('Math.round(innerHeight / 2):', Math.round(innerHeight / 2));
-
         // カード初期化
         const tmpList = getCardList();
         const dataList = tmpList.map(value => ({
@@ -67,7 +62,6 @@ const CardList = forwardRef<CardListHandle>((_, ref) => {
     }, []);
 
     const shuffleCards = () => {
-        //console.log('シャッフル処理を実行');
         if (isShuffling) return;
         setIsShuffling(true);
 
@@ -101,7 +95,6 @@ const CardList = forwardRef<CardListHandle>((_, ref) => {
     };
 
     const bindCards = () => {
-        //console.log('束ねる処理を実行');
         if (isBinding) return;
         setIsBinding(true);
 
@@ -132,7 +125,6 @@ const CardList = forwardRef<CardListHandle>((_, ref) => {
     };
 
     const verticalCards = () => {
-        console.log('縦にする処理を実行');
         if (isVertical) return;
         setIsVertical(true);
 

--- a/nextjs/src/components/CardList.tsx
+++ b/nextjs/src/components/CardList.tsx
@@ -46,14 +46,19 @@ const CardList = forwardRef<CardListHandle>((_, ref) => {
         const innerWidth = window.innerWidth;
         const innerHeight = window.innerHeight;
 
+        console.log('innerWidth:', innerWidth);
+        console.log('Math.round(innerWidth / 2):', Math.round(innerWidth / 2));
+        console.log('innerHeight:', innerHeight);
+        console.log('Math.round(innerHeight / 2):', Math.round(innerHeight / 2));
+
         // カード初期化
         const tmpList = getCardList();
         const dataList = tmpList.map(value => ({
             ...value,
             src: getCardBackFileName(),
-            top: `${getRandom(0, Math.round(innerWidth / 2))}px`,
-            left: `${getRandom(0, Math.round(innerHeight / 2))}px`,
-            width: `100px`,
+            top: `${getRandom(0, Math.round(innerHeight / 2))}px`,
+            left: `${getRandom(0, Math.round(innerWidth / 2))}px`,
+            width: `clamp(3.125rem, 1.654rem + 7.35vw, 6.25rem)`,
             transform: `0deg`,
             zIndex: getRandom(1, 100)
         }));
@@ -82,8 +87,8 @@ const CardList = forwardRef<CardListHandle>((_, ref) => {
         const newCardList = cardList.map((card, index) => ({
             ...card,
             src: getCardBackFileName(),
-            top: `${getRandom(0, Math.round(innerWidth / 2))}px`,
-            left: `${getRandom(0, Math.round(innerHeight / 2))}px`,
+            top: `${getRandom(0, Math.round(innerHeight / 2))}px`,
+            left: `${getRandom(0, Math.round(innerWidth / 2))}px`,
             transform: `rotate(${getRandom(0, 360)}deg)`,
             zIndex: zIndexArray[index] // ランダムなz-indexを割り当て
         }));


### PR DESCRIPTION
## 変更の概要
カードの初期配置をスマホ対応しました。

## 変更の目的や背景
スマホでページを開いた時にカードが画面からはみ出していて操作しづらいためです。

## 関連Issue
[](https://github.com/YoshihisaSaitou/quantum-card-app-3/issues/9)

## 動作確認
<!-- 動作確認の内容を記載してください -->
- [x] レイアウトが崩れていない
- [x] カードがはみ出してない