### PR TITLE
Feat/disable touch reload function

### DIFF
--- a/nextjs/package.json
+++ b/nextjs/package.json
@@ -1,28 +1,29 @@
 {
-  "name": "nextjs",
-  "version": "0.1.0",
-  "private": true,
-  "scripts": {
-    "dev": "next dev --turbopack",
-    "build": "next build",
-    "start": "next start",
-    "lint": "next lint"
-  },
-  "dependencies": {
-    "next": "15.1.2",
-    "react": "^19.0.0",
-    "react-dom": "^19.0.0"
-  },
-  "devDependencies": {
-    "@eslint/eslintrc": "^3",
-    "@tailwindcss/postcss": "^4.1.10",
-    "@types/node": "^20",
-    "@types/react": "^19",
-    "@types/react-dom": "^19",
-    "eslint": "^9",
-    "eslint-config-next": "15.1.2",
-    "postcss": "^8",
-    "tailwindcss": "^4.1.10",
-    "typescript": "^5"
-  }
+    "name": "nextjs",
+    "version": "0.1.0",
+    "private": true,
+    "scripts": {
+        "dev": "next dev --turbopack",
+        "build": "next build",
+        "postbuild": "touch out/.nojekyll",
+        "start": "next start",
+        "lint": "next lint"
+    },
+    "dependencies": {
+        "next": "15.1.2",
+        "react": "^19.0.0",
+        "react-dom": "^19.0.0"
+    },
+    "devDependencies": {
+        "@eslint/eslintrc": "^3",
+        "@tailwindcss/postcss": "^4.1.10",
+        "@types/node": "^20",
+        "@types/react": "^19",
+        "@types/react-dom": "^19",
+        "eslint": "^9",
+        "eslint-config-next": "15.1.2",
+        "postcss": "^8",
+        "tailwindcss": "^4.1.10",
+        "typescript": "^5"
+    }
 }

--- a/nextjs/src/app/globals.css
+++ b/nextjs/src/app/globals.css
@@ -25,7 +25,7 @@
 
     html,
     body {
-        @apply overscroll-x-contain;
+        @apply overscroll-contain;
     }
 }
 


### PR DESCRIPTION
## 変更の概要
タッチ操作の再読み込み機能を無効しました。
ビルド時に.nojekyllファイルを自動で作成するようにしました。

## 変更の目的や背景
カードを縦に移動する時に再読み込み機能が邪魔して縦に移動が困難なためです。
本番公開時に.nojekyllファイルの作成漏れを防ぐためにビルド時に自動で作成するようにしました。

## 関連Issue
[](https://github.com/YoshihisaSaitou/quantum-card-app-3/issues/11)

## 動作確認
<!-- 動作確認の内容を記載してください -->
- [x] レイアウトが崩れていない
- [x] タッチ操作の再読み込みが無効になってる。